### PR TITLE
Intégration du widget de clavardage sur le site.

### DIFF
--- a/src/components/LibChatWidget.jsx
+++ b/src/components/LibChatWidget.jsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+import Div from '@/components/utils/Div';
+
+const LIBCHAT_HASH = "71ff3bc4ca990e9e993a02e35e2f804aa581c52535e870359e707314a83afdd3";
+
+const LibChatWidget = () => {
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    // Injecter un style global pour masquer le bouton flottant LibChat
+    const style = document.createElement("style");
+    style.innerHTML = `
+      .s-lch-widget-float-btn {
+        display: none !important;
+        opacity: 0 !important;
+        pointer-events: none !important;
+        visibility: hidden !important;
+      }
+    `;
+    document.head.appendChild(style);
+
+    const existingScript = document.getElementById("libchat-script");
+    if (existingScript) return;
+
+    const script = document.createElement("script");
+    script.id = "libchat-script";
+    script.src = `https://unequestion.bib.umontreal.ca/load_chat.php?hash=${LIBCHAT_HASH}`;
+    script.async = true;
+
+    script.onload = () => {
+      window.libChatLoaded = true;
+    };
+
+    script.onerror = () => {
+      console.error("Échec du chargement du script LibChat.");
+      setError(true);
+      window.libChatLoaded = false;
+    };
+
+    document.body.appendChild(script);
+
+    window.openLibChatDirect = () => {
+      if (!window.libChatLoaded) {
+        alert("Le service de clavardage est temporairement indisponible.");
+        return;
+      }
+
+      const chatButton = document.querySelector(".s-lch-widget-float-btn");
+      const chatBoite = document.querySelector(".s-lch-widget-float");
+
+      if (chatButton) {
+        chatButton.style.opacity = "0";
+        chatButton.style.pointerEvents = "none";
+        chatButton.style.visibility = "hidden";
+        chatButton.click();
+      }
+
+      if (chatBoite) {
+        chatBoite.style.zIndex = "99999";
+      }
+    };
+
+    return () => {
+      window.openLibChatDirect = undefined;
+      window.libChatLoaded = false;
+      const addedScript = document.getElementById("libchat-script");
+      if (addedScript) {
+        addedScript.remove();
+      }
+    };
+  }, []);
+
+  return (
+    <>
+      <Div
+        id={`libchat_${LIBCHAT_HASH}`}
+        style={{
+          position: "fixed",
+          bottom: "80px",
+          right: "20px",
+          zIndex: 99999
+        }}
+      />
+      {error && (
+        <Div
+          sx={{
+            position: 'fixed',
+            bottom: '100px',
+            right: '20px',
+            backgroundColor: '#f44336',
+            color: '#fff',
+            padding: '10px 15px',
+            borderRadius: '8px',
+            zIndex: 99999,
+          }}
+        >
+          Le service de clavardage est temporairement indisponible.
+        </Div>
+      )}
+    </>
+  );
+};
+
+export default LibChatWidget;

--- a/src/components/_layout/QuickLinks.jsx
+++ b/src/components/_layout/QuickLinks.jsx
@@ -3,6 +3,7 @@ import { CalendarPlus, Chats, ClockCountdown, Lifebuoy } from '@phosphor-icons/r
 import Div from '@/components/utils/Div'
 import { SofiaIcon } from '@/components/CustomIcons'
 import Link from '@/components/Link'
+import LibChatWidget from '@/components/LibChatWidget';
 
 function ListItemText({ children }) {
   return (
@@ -32,6 +33,15 @@ export function QuickLinks() {
     alert('Action à définir')
   }
 
+  function handleChatClick(event) {
+    event.preventDefault();
+    if (typeof window.openLibChatDirect === 'function') {
+      window.openLibChatDirect();
+    } else {
+      console.error("La fonction openLibChatDirect n'est pas disponible");
+    }
+  }
+
   return (
     <Div
       sx={{
@@ -47,6 +57,7 @@ export function QuickLinks() {
         pointerEvents: 'none',
       }}
     >
+      <LibChatWidget />
       <Paper
         component="nav"
         elevation={3}
@@ -90,7 +101,7 @@ export function QuickLinks() {
             </ListItemIcon>
             <ListItemText>Soutien informatique</ListItemText>
           </MenuItem>
-          <MenuItem component={Link} to="#" onClick={handleOnMenuItemClick}>
+          <MenuItem component={Link} to="#" onClick={handleChatClick}>
             <ListItemIcon>
               <Chats color="#fff" size={24} />
             </ListItemIcon>
@@ -108,6 +119,15 @@ export function QuickLinksSm() {
   function handleOnMenuItemClick(event) {
     event.preventDefault()
     alert('Action à définir')
+  }
+
+  function handleChatClick(event) {
+    event.preventDefault();
+    if (typeof window.openLibChatDirect === 'function') {
+      window.openLibChatDirect();
+    } else {
+      console.error("La fonction openLibChatDirect n'est pas disponible");
+    }
   }
 
   return (
@@ -130,6 +150,7 @@ export function QuickLinksSm() {
         boxShadow: theme.shadows[3],
       }}
     >
+      <LibChatWidget />
       <Box
         component="nav"
         elevation={3}
@@ -152,7 +173,7 @@ export function QuickLinksSm() {
         <IconButton component={Link} href="#" onClick={handleOnMenuItemClick} aria-label="Soutien informatique">
           <Lifebuoy color="#fff" size={40} />
         </IconButton>
-        <IconButton component={Link} href="#" onClick={handleOnMenuItemClick} aria-label="Clavarder">
+        <IconButton component={Link} href="#" onClick={handleChatClick} aria-label="Clavarder">
           <Chats color="#fff" size={40} />
         </IconButton>
       </Box>


### PR DESCRIPTION
Le bouton est caché par défaut et son fonctionnement est intégré au menu local « Clavarder ». L’intégration a été réalisée pour les écrans de bureau et les appareils mobiles.