### PR TITLE
fix: retrait du wordSpacing négatif sur les titres d'événements et de nouvelles causant un rendu illisible sur Safari iOS

### DIFF
--- a/src/components/ListeEvenements.jsx
+++ b/src/components/ListeEvenements.jsx
@@ -63,7 +63,6 @@ function Title({ children }) {
         lineHeight: 1.5,
         paddingTop: '1.5rem',
         color: 'var(--_title-color)',
-        wordSpacing: '-0.2em',
       }}
     >
       {children}

--- a/src/components/ListeNouvellesAccueil.jsx
+++ b/src/components/ListeNouvellesAccueil.jsx
@@ -65,7 +65,6 @@ const Title = React.memo(({ children }) => (
       fontSize: '1.75rem',
       fontWeight: 500,
       lineHeight: 1.3,
-      wordSpacing: '-0.2em',
       [theme.breakpoints.down('sm')]: {
         fontSize: '1.5rem',
         lineHeight: 1.2,


### PR DESCRIPTION
… nouvelles causant un rendu illisible sur Safari iOS